### PR TITLE
Remove unused bootstrap dependency from package.json

### DIFF
--- a/examples/CustomDataframe/frontend/package.json
+++ b/examples/CustomDataframe/frontend/package.json
@@ -7,7 +7,6 @@
     "@material-ui/icons": "^4.9.1",
     "apache-arrow": "^0.17.0",
     "baseui": "^9.73.2",
-    "bootstrap": "^4.4.1",
     "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/examples/RadioButton/frontend/package.json
+++ b/examples/RadioButton/frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "baseui": "^9.73.2",
-    "bootstrap": "^4.4.1",
     "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/examples/SelectableDataTable/frontend/package.json
+++ b/examples/SelectableDataTable/frontend/package.json
@@ -16,7 +16,6 @@
     "@material-ui/icons": "^4.9.1",
     "apache-arrow": "^0.17.0",
     "baseui": "^9.73.2",
-    "bootstrap": "^4.4.1",
     "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/template-reactless/my_component/frontend/package.json
+++ b/template-reactless/my_component/frontend/package.json
@@ -8,7 +8,6 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "bootstrap": "^4.4.1",
     "react-scripts": "3.4.1",
     "streamlit-component-lib": "^1.0.0",
     "typescript": "~3.7.2"

--- a/template/my_component/frontend/package.json
+++ b/template/my_component/frontend/package.json
@@ -10,7 +10,6 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
-    "bootstrap": "^4.4.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",


### PR DESCRIPTION
We're loading bootstrap's CSS via a minified CSS file that lives in public/. The npm dependency is not used.

Closes #6