### PR TITLE
Bump streamlit-component-lib to 1.1.0

### DIFF
--- a/examples/CustomDataframe/frontend/package.json
+++ b/examples/CustomDataframe/frontend/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "reactstrap": "^8.4.1",
-    "streamlit-component-lib": "^1.0.0"
+    "streamlit-component-lib": "^1.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/MaterialLogin/frontend/package.json
+++ b/examples/MaterialLogin/frontend/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "reactstrap": "^8.4.1",
-    "streamlit-component-lib": "^1.0.0",
+    "streamlit-component-lib": "^1.1.0",
     "styletron-engine-atomic": "^1.4.6",
     "styletron-react": "^5.2.7",
     "yup": "^0.29.1"

--- a/examples/RadioButton/frontend/package.json
+++ b/examples/RadioButton/frontend/package.json
@@ -9,7 +9,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "reactstrap": "^8.4.1",
-    "streamlit-component-lib": "^1.0.0",
+    "streamlit-component-lib": "^1.1.0",
     "styletron-engine-atomic": "^1.4.6",
     "styletron-react": "^5.2.7"
   },

--- a/examples/SelectableDataTable/frontend/package.json
+++ b/examples/SelectableDataTable/frontend/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "reactstrap": "^8.4.1",
-    "streamlit-component-lib": "^1.0.0",
+    "streamlit-component-lib": "^1.1.0",
     "styletron-engine-atomic": "^1.4.6",
     "styletron-react": "^5.2.7"
   },

--- a/template-reactless/my_component/frontend/package.json
+++ b/template-reactless/my_component/frontend/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
     "react-scripts": "3.4.1",
-    "streamlit-component-lib": "^1.0.0",
+    "streamlit-component-lib": "^1.1.0",
     "typescript": "~3.7.2"
   },
   "scripts": {

--- a/template/my_component/frontend/package.json
+++ b/template/my_component/frontend/package.json
@@ -13,7 +13,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
-    "streamlit-component-lib": "^1.0.0",
+    "streamlit-component-lib": "^1.1.0",
     "typescript": "~3.7.2"
   },
   "scripts": {


### PR DESCRIPTION
This version was just published, and adds `bytes` <-> `Uint8Array` support