### PR TITLE
Provide examples for using themes in components

### DIFF
--- a/template-reactless/my_component/frontend/package.json
+++ b/template-reactless/my_component/frontend/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
     "react-scripts": "3.4.1",
-    "streamlit-component-lib": "^1.1.3",
+    "streamlit-component-lib": "1.2.0-beta.0",
     "typescript": "~3.7.2"
   },
   "scripts": {
@@ -22,11 +22,7 @@
     "extends": "react-app"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/template-reactless/my_component/frontend/src/index.tsx
+++ b/template-reactless/my_component/frontend/src/index.tsx
@@ -9,11 +9,20 @@ button.textContent = "Click Me!"
 
 // Add a click handler to our button. It will send data back to Streamlit.
 let numClicks = 0
+let isFocused = false
 button.onclick = function(): void {
   // Increment numClicks, and pass the new value back to
   // Streamlit via `Streamlit.setComponentValue`.
   numClicks += 1
   Streamlit.setComponentValue(numClicks)
+}
+
+button.onfocus = function(): void {
+  isFocused = true
+}
+
+button.onblur = function(): void {
+  isFocused = false
 }
 
 /**
@@ -24,6 +33,18 @@ button.onclick = function(): void {
 function onRender(event: Event): void {
   // Get the RenderData from the event
   const data = (event as CustomEvent<RenderData>).detail
+
+  // Maintain compatibility with older versions of Streamlit that don't send
+  // a theme object.
+  if (data.theme) {
+    // Use CSS vars to style our button border. Alternatively, the theme style
+    // is defined in the data.theme object.
+    const borderStyling = `1px solid var(${
+      isFocused ? "--primary-color" : "--secondary-color"
+    })`
+    button.style.border = borderStyling
+    button.style.outline = borderStyling
+  }
 
   // Disable our button if necessary.
   button.disabled = data.disabled

--- a/template/my_component/frontend/package.json
+++ b/template/my_component/frontend/package.json
@@ -13,7 +13,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
-    "streamlit-component-lib": "^1.1.3",
+    "streamlit-component-lib": "1.2.0-beta.0",
     "typescript": "~3.7.2"
   },
   "scripts": {
@@ -26,11 +26,7 @@
     "extends": "react-app"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/template/my_component/frontend/src/MyComponent.tsx
+++ b/template/my_component/frontend/src/MyComponent.tsx
@@ -1,12 +1,13 @@
 import {
   Streamlit,
   StreamlitComponentBase,
-  withStreamlitConnection
-} from "streamlit-component-lib";
+  withStreamlitConnection,
+} from "streamlit-component-lib"
 import React, { ReactNode } from "react"
 
 interface State {
   numClicks: number
+  isFocused: boolean
 }
 
 /**
@@ -14,12 +15,30 @@ interface State {
  * automatically when your component should be re-rendered.
  */
 class MyComponent extends StreamlitComponentBase<State> {
-  public state = { numClicks: 0 }
+  public state = { numClicks: 0, isFocused: false }
 
   public render = (): ReactNode => {
     // Arguments that are passed to the plugin in Python are accessible
     // via `this.props.args`. Here, we access the "name" arg.
     const name = this.props.args["name"]
+
+    // Streamlit sends us a theme object via props that we can use to ensure
+    // that our component has visuals that match the active theme in a
+    // streamlit app.
+    const { theme } = this.props
+    const style: React.CSSProperties = {}
+
+    // Maintain compatibility with older versions of Streamlit that don't send
+    // a theme object.
+    if (theme) {
+      // Use the theme object to style our button border. Alternatively, the
+      // theme style is defined in CSS vars.
+      const borderStyling = `1px solid ${
+        this.state.isFocused ? theme.primaryColor : theme.secondaryColor
+      }`
+      style.border = borderStyling
+      style.outline = borderStyling
+    }
 
     // Show a button and some text.
     // When the button is clicked, we'll increment our "numClicks" state
@@ -28,7 +47,13 @@ class MyComponent extends StreamlitComponentBase<State> {
     return (
       <span>
         Hello, {name}! &nbsp;
-        <button onClick={this.onClicked} disabled={this.props.disabled}>
+        <button
+          style={style}
+          onClick={this.onClicked}
+          disabled={this.props.disabled}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
+        >
           Click Me!
         </button>
       </span>
@@ -43,6 +68,16 @@ class MyComponent extends StreamlitComponentBase<State> {
       prevState => ({ numClicks: prevState.numClicks + 1 }),
       () => Streamlit.setComponentValue(this.state.numClicks)
     )
+  }
+
+  /** Focus handler for our "Click Me!" button. */
+  private _onFocus = (): void => {
+    this.setState({ isFocused: true })
+  }
+
+  /** Blur handler for our "Click Me!" button. */
+  private _onBlur = (): void => {
+    this.setState({ isFocused: false })
   }
 }
 


### PR DESCRIPTION
Examples for both `template/` and `template-reactless` are provided.

Note that we'll probably want to wait until theming is officially released before merging these in, so this PR is going into a new `theming` branch that can eventually be merged into `master` once theming is released.