### PR TITLE
Remove @testing-library dependencies

### DIFF
--- a/template-reactless/my_component/frontend/package.json
+++ b/template-reactless/my_component/frontend/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
     "react-scripts": "3.4.1",

--- a/template/my_component/frontend/package.json
+++ b/template/my_component/frontend/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",


### PR DESCRIPTION
These are unused in the template, and they introduce a conflicting version of react types that breaks the build.

After this change, I'm able to `yarn install && yarn start` (or `npm install && npm run start`)