### PR TITLE
Update typescript in templates

### DIFF
--- a/template-reactless/my_component/frontend/package.json
+++ b/template-reactless/my_component/frontend/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^12.0.0",
     "react-scripts": "3.4.1",
     "streamlit-component-lib": "^1.3.0",
-    "typescript": "~3.8.0"
+    "typescript": "^4.6.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/template-reactless/my_component/frontend/package.json
+++ b/template-reactless/my_component/frontend/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^12.0.0",
     "react-scripts": "3.4.1",
     "streamlit-component-lib": "^1.3.0",
-    "typescript": "^4.6.3"
+    "typescript": "^4.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/template/my_component/frontend/package.json
+++ b/template/my_component/frontend/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "streamlit-component-lib": "^1.3.0",
-    "typescript": "~3.8.0"
+    "typescript": "^4.6.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/template/my_component/frontend/package.json
+++ b/template/my_component/frontend/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "streamlit-component-lib": "^1.3.0",
-    "typescript": "^4.6.3"
+    "typescript": "^4.2.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This fixes them no longer building due to type errors latest version of the types for babel__traverse.