### PR TITLE
Add basic CI setup for examples

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: 
+      - "master"
+  pull_request:
+    branches: 
+      - "master"
+
+jobs:
+  build-examples:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: 
+          - 14.x
+          # As of 2023-05-08, newer versions of node are not supported due to a compatibility
+          #  issue with the transient dependency - node-sass.
+
+    name: Examples / node-version=${{ matrix.node-version }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+
+    - uses: actions/setup-python@v4
+      with:
+        # Python 2.7 is required to install node-gyp. It is required to install node-sass.
+        python-version: '2.7'
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install node dependencies
+      run: ./dev.py examples-npm-install
+
+    - name: Build frontend code
+      run: ./dev.py examples-npm-build

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import argparse
+from glob import glob
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+THIS_DIRECTORY = Path(__file__).parent.absolute()
+EXAMPLE_DIRECTORIES = (d for d in (THIS_DIRECTORY / 'examples').iterdir() if d.is_dir())
+
+# Utilities function
+def run_verbose(cmd_args, *args, **kwargs):
+    kwargs.setdefault("check", True)
+    cwd = kwargs.get('cwd')
+    message_suffix = f" [CWD: {Path(cwd).relative_to(THIS_DIRECTORY)}]" if cwd else ''
+
+    print(f"$ {shlex.join(cmd_args)}{message_suffix}", flush=True)
+    subprocess.run(cmd_args, *args, **kwargs)
+
+
+# Commands
+def cmd_example_npm_install(args):
+    """"Install all node dependencies for all examples"""
+    for example_dir in EXAMPLE_DIRECTORIES:
+        run_verbose(["npm", "install"], cwd=str(example_dir / "frontend"))
+
+
+def cmd_example_npm_build(args):
+    """"Build javascript code for all examples"""
+    for example_dir in EXAMPLE_DIRECTORIES:
+        run_verbose(["npm", "run", "build"], cwd=str(example_dir / "frontend"))
+
+COMMMANDS = {
+    "examples-npm-install": cmd_example_npm_install,
+    "examples-npm-build": cmd_example_npm_build,
+}
+
+# Parser    
+def get_parser():
+    parser = argparse.ArgumentParser(prog=__file__)
+    subparsers = parser.add_subparsers(dest="subcommand", metavar="COMMAND")
+    subparsers.required = True
+    for commmand_name, command_fn in COMMMANDS.items():
+        subparsers.add_parser(commmand_name, help=command_fn.__doc__).set_defaults(func=command_fn)
+    return parser
+
+
+# Main function
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We don't have any tests for the examples we have in this repository. At the beginning, we can start with compiling the code, because this causes different problems on different versions of Node.

Once we know that the code is compiling, we can add other tests, including E2E tests.