### PR TITLE
Fix quick start guide to involve installing editable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ npm run start  # Start the Webpack dev server
 ```
 $ cd template
 $ . venv/bin/activate  # activate the venv you created earlier
+$ pip install -e . # install template as editable package
 $ streamlit run my_component/example.py  # run the example
 ```
 * If all goes well, you should see something like this:


### PR DESCRIPTION
Fix quick start guide to involve installing editable package.
When we extracted example.py file we use `import my_component` which is not installed yet.