### PR TITLE
Set Streamlit Ecosystem and Streamlit Open Source teams as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @streamlit/ecosystem
+*   @streamlit/ecosystem @streamlit/streamlit-open-source

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @streamlit/ecosystem


### PR DESCRIPTION
This change sets `streamlit/ecosystem` and `streamlit/streamlit-open-source` teams as code owners