### PR TITLE
Upgrade Playwright to 1.39.0 to support Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PIP_VERSION=${PIP_VERSION}
 RUN pip install --no-cache-dir --upgrade "pip==${PIP_VERSION}" && pip --version
 
 # Setup Playwright
-ARG PLAYWRIGHT_VERSION="1.36.0"
+ARG PLAYWRIGHT_VERSION="1.39.0"
 ENV PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION}
 
 RUN pip install --no-cache-dir playwright=="${PLAYWRIGHT_VERSION}" && playwright install webkit chromium firefox --with-deps


### PR DESCRIPTION
Use the latest Playwright to support Python 3.12