### PR TITLE
Add some quick fixes for test flakiness 

### DIFF
--- a/examples/SelectableDataTable/e2e/test_selectable_data_table.py
+++ b/examples/SelectableDataTable/e2e/test_selectable_data_table.py
@@ -48,16 +48,16 @@ def test_should_render_selectable_data_table(page: Page):
 
     first_row_checkbox.uncheck()
     expect(root_checkbox).not_to_be_checked()
-    assert root_checkbox.get_attribute('data-indeterminate') == "true"
+    expect(first_row_checkbox).to_have_attribute('data-indeterminate', 'true')
 
     for checkbox in none_root_checkboxes:
         checkbox.uncheck()
 
     expect(root_checkbox).not_to_be_checked()
-    assert root_checkbox.get_attribute('data-indeterminate') == 'false'
+    expect(root_checkbox).to_have_attribute('data-indeterminate', 'false')
 
     for checkbox in none_root_checkboxes:
         checkbox.check()
 
     expect(root_checkbox).to_be_checked()
-    assert root_checkbox.get_attribute('data-indeterminate') == 'false'
+    expect(root_checkbox).to_have_attribute('data-indeterminate', 'false')

--- a/template-reactless/e2e/test_template.py
+++ b/template-reactless/e2e/test_template.py
@@ -65,6 +65,7 @@ def test_should_change_iframe_height(page: Page):
 
     locator = page.locator('iframe[title="my_component\\.my_component"]').nth(1)
 
+    page.wait_for_timeout(1000)
     init_frame_height = locator.bounding_box()['height']
     assert init_frame_height != 0
 
@@ -75,6 +76,7 @@ def test_should_change_iframe_height(page: Page):
 
     expect(frame.get_by_text("Streamlit Streamlit Streamlit")).to_be_visible()
 
+    page.wait_for_timeout(1000)
     frame_height = locator.bounding_box()['height']
     assert frame_height > init_frame_height
 
@@ -82,5 +84,6 @@ def test_should_change_iframe_height(page: Page):
 
     expect(frame.get_by_text("Streamlit Streamlit Streamlit")).not_to_be_in_viewport()
 
+    page.wait_for_timeout(1000)
     frame_height_after_viewport_change = locator.bounding_box()['height']
     assert frame_height_after_viewport_change > frame_height

--- a/template/e2e/test_template.py
+++ b/template/e2e/test_template.py
@@ -65,6 +65,7 @@ def test_should_change_iframe_height(page: Page):
 
     locator = page.locator('iframe[title="my_component\\.my_component"]').nth(1)
 
+    page.wait_for_timeout(1000)
     init_frame_height = locator.bounding_box()['height']
     assert init_frame_height != 0
 
@@ -75,6 +76,7 @@ def test_should_change_iframe_height(page: Page):
 
     expect(frame.get_by_text("Streamlit Streamlit Streamlit")).to_be_visible()
 
+    page.wait_for_timeout(1000)
     frame_height = locator.bounding_box()['height']
     assert frame_height > init_frame_height
 
@@ -82,5 +84,6 @@ def test_should_change_iframe_height(page: Page):
 
     expect(frame.get_by_text("Streamlit Streamlit Streamlit")).not_to_be_in_viewport()
 
+    page.wait_for_timeout(1000)
     frame_height_after_viewport_change = locator.bounding_box()['height']
     assert frame_height_after_viewport_change > frame_height


### PR DESCRIPTION
The e2e tests are quite flaky (caused by the usage of assert). This just applies some quick fixes by using some timouts. I will try to properly address these tests in a later PR. 