### PR TITLE
Migrate upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
     - name: Upload wheel packages
       uses: actions/upload-artifact@v4
       with:
-        name: all-wheel
+        name: all-wheel-${{ matrix.node_version }}-${{ matrix.component_lib_version }}-${{ matrix.streamlit_version }}
         path: ${{ steps.component_wheels.outputs.output_directory }}/*.whl
         if-no-files-found: error
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
           ${{ matrix.component_lib_version == 'develop' && steps.streamlit_component_library.outputs.output_file || '' }}
 
     - name: Upload wheel packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: all-wheel
         path: ${{ steps.component_wheels.outputs.output_directory }}/*.whl


### PR DESCRIPTION
v3 has been deprecated and will be removed, so we will update this to v4. Based on the breaking changes, I believe we just need to update the name of the artifacts to be all different.