### PR TITLE
Use `rimraf` instead of `rm -rf`

### DIFF
--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/package.json
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && npm run typecheck && npm run build:frontend:production",
     "build:frontend:production": "NODE_ENV=production vite build",
-    "clean": "rm -rf build",
+    "clean": "rimraf build",
     "dev": "NODE_ENV=development vite build --watch",
     "format": "prettier --write src/**/*.{ts,tsx} vite.config.ts",
     "typecheck": "tsc --noEmit"
@@ -29,6 +29,7 @@
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react": "^5.1.0",
     "prettier": "^3.6.2",
+    "rimraf": "^6.1.0",
     "typescript": "^5.8.3",
     "vite": "^7.1.12"
   }

--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/package.json
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && npm run typecheck && npm run build:frontend:production",
     "build:frontend:production": "NODE_ENV=production vite build",
-    "clean": "rm -rf build",
+    "clean": "rimraf build",
     "dev": "NODE_ENV=development vite build --watch",
     "format": "prettier --write src/**/*.ts vite.config.ts",
     "typecheck": "tsc --noEmit"
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "prettier": "^3.6.2",
+    "rimraf": "^6.1.0",
     "typescript": "^5.8.3",
     "vite": "^7.1.12"
   }

--- a/templates/v2/template-reactless/my_component/frontend/package.json
+++ b/templates/v2/template-reactless/my_component/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && npm run typecheck && npm run build:frontend:production",
     "build:frontend:production": "NODE_ENV=production vite build",
-    "clean": "rm -rf build",
+    "clean": "rimraf build",
     "dev": "NODE_ENV=development vite build --watch",
     "format": "prettier --write src/**/*.ts vite.config.ts",
     "typecheck": "tsc --noEmit"
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "prettier": "^3.6.2",
+    "rimraf": "^6.1.0",
     "typescript": "^5.8.3",
     "vite": "^7.1.12"
   }

--- a/templates/v2/template/my_component/frontend/package.json
+++ b/templates/v2/template/my_component/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && npm run typecheck && npm run build:frontend:production",
     "build:frontend:production": "NODE_ENV=production vite build",
-    "clean": "rm -rf build",
+    "clean": "rimraf build",
     "dev": "NODE_ENV=development vite build --watch",
     "format": "prettier --write src/**/*.{ts,tsx} vite.config.ts",
     "typecheck": "tsc --noEmit"
@@ -29,6 +29,7 @@
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react": "^5.1.0",
     "prettier": "^3.6.2",
+    "rimraf": "^6.1.0",
     "typescript": "^5.8.3",
     "vite": "^7.1.12"
   }


### PR DESCRIPTION
I propose using [rimraf](https://www.npmjs.com/package/rimraf) instead of rm so the template can be cross-platform.