### PR TITLE
[fix] Add prettier as dev dependency to v1 templates

### DIFF
--- a/cookiecutter/v1/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/package.json
+++ b/cookiecutter/v1/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react-swc": "^3.9.0",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.4.1"
   }

--- a/cookiecutter/v1/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/package.json
+++ b/cookiecutter/v1/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.1",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.4.1"
   },

--- a/examples/v1/CustomDataframe/custom_dataframe/frontend/package-lock.json
+++ b/examples/v1/CustomDataframe/custom_dataframe/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react": "^18.3.20",
         "@types/react-dom": "^18.3.6",
         "@vitejs/plugin-react-swc": "^3.9.0",
+        "prettier": "^3.6.2",
         "typescript": "^5.8.3",
         "vite": "^6.4.1"
       }
@@ -1501,6 +1502,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -2732,6 +2749,12 @@
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
+    },
+    "prettier": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
+      "dev": true
     },
     "prop-types": {
       "version": "15.8.1",

--- a/examples/v1/CustomDataframe/custom_dataframe/frontend/package.json
+++ b/examples/v1/CustomDataframe/custom_dataframe/frontend/package.json
@@ -35,6 +35,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react-swc": "^3.9.0",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.4.1"
   }

--- a/examples/v1/MaterialLogin/material_login/frontend/package-lock.json
+++ b/examples/v1/MaterialLogin/material_login/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "^18.3.6",
         "@types/yup": "^0.29.3",
         "@vitejs/plugin-react-swc": "^3.9.0",
+        "prettier": "^3.6.2",
         "typescript": "^5.8.3",
         "vite": "^6.4.1"
       }
@@ -2305,6 +2306,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4174,6 +4191,12 @@
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
+    },
+    "prettier": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
+      "dev": true
     },
     "prop-types": {
       "version": "15.8.1",

--- a/examples/v1/MaterialLogin/material_login/frontend/package.json
+++ b/examples/v1/MaterialLogin/material_login/frontend/package.json
@@ -43,6 +43,7 @@
     "@types/react-dom": "^18.3.6",
     "@types/yup": "^0.29.3",
     "@vitejs/plugin-react-swc": "^3.9.0",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.4.1"
   }

--- a/examples/v1/RadioButton/radio_button/frontend/package-lock.json
+++ b/examples/v1/RadioButton/radio_button/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react": "^18.3.20",
         "@types/react-dom": "^18.3.6",
         "@vitejs/plugin-react-swc": "^3.9.0",
+        "prettier": "^3.6.2",
         "typescript": "^5.8.3",
         "vite": "^6.4.1"
       }
@@ -1025,6 +1026,7 @@
       "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1044,6 +1046,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1551,7 +1554,8 @@
     "node_modules/d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "peer": true
     },
     "node_modules/d3-shape": {
       "version": "2.1.0",
@@ -1613,6 +1617,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -2007,6 +2012,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2064,6 +2070,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -2091,6 +2113,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2114,6 +2137,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2335,6 +2359,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -2382,6 +2407,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/styletron-react/-/styletron-react-6.1.0.tgz",
       "integrity": "sha512-PHT5KUaTJKmZdA3W6lV7M+/mgn0+JzuFRiteVZHw3ApLlXwkAZMMy2NwyBwRfx/Q5EZyJvQtoOCif6hY0nVWaA==",
+      "peer": true,
       "dependencies": {
         "prop-types": "^15.6.0",
         "styletron-standard": "^3.1.0"
@@ -2539,6 +2565,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3158,6 +3185,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
       "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "undici-types": "~6.21.0"
       }
@@ -3176,6 +3204,7 @@
       "version": "18.3.20",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3625,7 +3654,8 @@
     "d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "peer": true
     },
     "d3-shape": {
       "version": "2.1.0",
@@ -3684,6 +3714,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
@@ -3976,7 +4007,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "polished": {
       "version": "3.7.2",
@@ -4002,6 +4034,12 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "prettier": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
+      "dev": true
+    },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4025,6 +4063,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -4041,6 +4080,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4193,6 +4233,7 @@
           "version": "16.14.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
           "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "peer": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
@@ -4234,6 +4275,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/styletron-react/-/styletron-react-6.1.0.tgz",
       "integrity": "sha512-PHT5KUaTJKmZdA3W6lV7M+/mgn0+JzuFRiteVZHw3ApLlXwkAZMMy2NwyBwRfx/Q5EZyJvQtoOCif6hY0nVWaA==",
+      "peer": true,
       "requires": {
         "prop-types": "^15.6.0",
         "styletron-standard": "^3.1.0"
@@ -4334,6 +4376,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/examples/v1/RadioButton/radio_button/frontend/package.json
+++ b/examples/v1/RadioButton/radio_button/frontend/package.json
@@ -38,6 +38,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react-swc": "^3.9.0",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.4.1"
   }

--- a/templates/v1/template-reactless/my_component/frontend/package.json
+++ b/templates/v1/template-reactless/my_component/frontend/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.1",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.4.1"
   },

--- a/templates/v1/template/my_component/frontend/package.json
+++ b/templates/v1/template/my_component/frontend/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react-swc": "^3.9.0",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.4.1"
   }


### PR DESCRIPTION
- The v1 templates have a `.prettierrc` file, but no dev dependency on `prettier`. This fixes that.
- Fixes #8 