### PR TITLE
[feat] Add JSONSchemas

### DIFF
--- a/directory/schemas/compiled.schema.json
+++ b/directory/schemas/compiled.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/compiled.schema.json",
+  "title": "Component Gallery compiled catalog (compiled/components.json)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["generatedAt", "schemaVersion", "categories", "components"],
+  "properties": {
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "schemaVersion": { "type": "integer", "const": 1 },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string" }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "author",
+          "socialUrl",
+          "pipLink",
+          "categories",
+          "image",
+          "gitHubUrl",
+          "enabled",
+          "appUrl"
+        ],
+        "properties": {
+          "title": { "type": "string", "minLength": 1 },
+          "author": { "type": "string", "minLength": 1 },
+          "pipLink": {
+            "oneOf": [
+              { "type": "string", "minLength": 1 },
+              { "type": "null" }
+            ]
+          },
+          "pypi": {
+            "oneOf": [
+              { "type": "string", "minLength": 1 },
+              { "type": "null" }
+            ]
+          },
+          "categories": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          },
+          "image": { "type": ["string", "null"], "format": "uri" },
+          "gitHubUrl": { "type": "string", "format": "uri" },
+          "enabled": { "type": "boolean" },
+          "appUrl": { "type": ["string", "null"], "format": "uri" },
+          "socialUrl": { "type": ["string", "null"], "format": "uri" },
+          "metrics": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "github": {
+                "type": ["object", "null"],
+                "additionalProperties": false,
+                "properties": {
+                  "stars": { "type": ["integer", "null"], "minimum": 0 },
+                  "forks": { "type": ["integer", "null"], "minimum": 0 },
+                  "contributorsCount": {
+                    "type": ["integer", "null"],
+                    "minimum": 0
+                  },
+                  "openIssues": { "type": ["integer", "null"], "minimum": 0 },
+                  "lastPushAt": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  },
+                  "fetchedAt": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  },
+                  "isStale": { "type": ["boolean", "null"] }
+                }
+              },
+              "pypi": {
+                "type": ["object", "null"],
+                "additionalProperties": false,
+                "properties": {
+                  "latestVersion": {
+                    "oneOf": [
+                      { "type": "string", "minLength": 1 },
+                      { "type": "null" }
+                    ]
+                  },
+                  "latestReleaseAt": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  },
+                  "fetchedAt": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  },
+                  "isStale": { "type": ["boolean", "null"] }
+                }
+              },
+              "pypistats": {
+                "type": ["object", "null"],
+                "additionalProperties": false,
+                "properties": {
+                  "lastDay": { "type": ["integer", "null"], "minimum": 0 },
+                  "lastWeek": { "type": ["integer", "null"], "minimum": 0 },
+                  "lastMonth": { "type": ["integer", "null"], "minimum": 0 },
+                  "fetchedAt": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  },
+                  "isStale": { "type": ["boolean", "null"] }
+                }
+              }
+            }
+          },
+          "ranking": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["score", "signals", "computedAt"],
+            "properties": {
+              "score": { "type": "number" },
+              "computedAt": { "type": "string", "format": "date-time" },
+              "signals": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "starsScore": { "type": ["number", "null"] },
+                  "recencyScore": { "type": ["number", "null"] },
+                  "daysSinceUpdate": {
+                    "type": ["number", "null"],
+                    "minimum": 0
+                  },
+                  "contributorsScore": { "type": ["number", "null"] },
+                  "daysSinceGithubPush": {
+                    "type": ["number", "null"],
+                    "minimum": 0
+                  },
+                  "daysSincePypiRelease": {
+                    "type": ["number", "null"],
+                    "minimum": 0
+                  },
+                  "downloadsScore": { "type": ["number", "null"] }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/directory/schemas/component.schema.json
+++ b/directory/schemas/component.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/component.schema.json",
+  "title": "Component Gallery submission (source-of-truth)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "title", "author", "links", "governance", "categories"],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "author": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["github"],
+      "properties": {
+        "github": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 39,
+          "pattern": "^[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*$",
+          "description": "GitHub username (no @)."
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["github"],
+      "properties": {
+        "github": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://github\\.com/[^/]+/[^/]+/?$"
+        },
+        "pypi": {
+          "type": ["string", "null"],
+          "pattern": "^[A-Za-z0-9_.-]+$",
+          "description": "PyPI project name (not a URL)."
+        },
+        "demo": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "docs": {
+          "type": ["string", "null"],
+          "format": "uri"
+        }
+      }
+    },
+    "media": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": ["string", "null"],
+          "format": "uri"
+        }
+      }
+    },
+    "install": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pip": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "maxLength": 200
+        }
+      }
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": ["string", "null"],
+          "maxLength": 500
+        }
+      }
+    },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "LLMs",
+          "Widgets",
+          "Charts",
+          "Authentication",
+          "Connections",
+          "Images & video",
+          "Audio",
+          "Text",
+          "Maps",
+          "Dataframes",
+          "Graphs",
+          "Molecules & genes",
+          "Code editors",
+          "Page navigation",
+          "Developer tools",
+          "Integrations"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR

Added JSON schema definitions for the Component Gallery catalog system.

### What changed?

- Created `compiled.schema.json` which defines the structure for the compiled components catalog
- Created `component.schema.json` which defines the structure for individual component submissions
- Both schemas include detailed validation rules for component metadata including:
    - Required fields (title, author, links, categories)
    - Format validation for URLs, dates, and other fields
    - Constraints on field lengths and content patterns
    - Predefined category options for components

### Why make this change?

These schema definitions provide a standardized structure for component submissions and the compiled catalog, ensuring:

1. Consistent data format for all components in the gallery
2. Proper validation of component metadata
3. Clear requirements for contributors submitting new components
4. Structured format for metrics and ranking data
5. Foundation for automated validation in the submission process