### PR TITLE
feat: upgrade v2 templates to TypeScript 6 and Vite 8

### DIFF
--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/package.json
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/package.json
@@ -27,11 +27,11 @@
     "@types/node": "^22.14.1",
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
-    "@vitejs/plugin-react": "^5.1.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "cross-env": "^10.1.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.1.0",
-    "typescript": "^5.8.3",
-    "vite": "^7.1.12"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
   }
 }

--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/tsconfig.json
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/vite.config.ts
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-react/vite.config.ts
@@ -1,6 +1,6 @@
 import react from "@vitejs/plugin-react";
 import process from "node:process";
-import { defineConfig, loadEnv, UserConfig } from "vite";
+import { defineConfig, UserConfig } from "vite";
 
 /**
  * Vite configuration for Streamlit Custom Component v2 development using React.
@@ -20,7 +20,7 @@ export default defineConfig(() => {
       "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
     build: {
-      minify: isDev ? false : "esbuild",
+      minify: isDev ? false : "oxc",
       outDir: "build",
       sourcemap: isDev,
       lib: {
@@ -30,11 +30,15 @@ export default defineConfig(() => {
         fileName: "index-[hash]",
       },
       ...(!isDev && {
-        esbuild: {
-          drop: ["console", "debugger"],
-          minifyIdentifiers: true,
-          minifySyntax: true,
-          minifyWhitespace: true,
+        rolldownOptions: {
+          output: {
+            minify: {
+              compress: {
+                dropConsole: true,
+                dropDebugger: true,
+              },
+            },
+          },
         },
       }),
     },

--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/package.json
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/package.json
@@ -25,8 +25,8 @@
     "cross-env": "^10.1.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.1.0",
-    "typescript": "^5.8.3",
-    "vite": "^7.1.12"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
   }
 }
 

--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/tsconfig.json
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/vite.config.ts
+++ b/cookiecutter/v2/{{ cookiecutter.package_name }}/{{ cookiecutter.import_name }}/frontend-reactless/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(() => {
       "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
     build: {
-      minify: isDev ? false : "esbuild",
+      minify: isDev ? false : "oxc",
       outDir: "build",
       sourcemap: isDev,
       lib: {
@@ -24,11 +24,15 @@ export default defineConfig(() => {
         fileName: "index-[hash]",
       },
       ...(!isDev && {
-        esbuild: {
-          drop: ["console", "debugger"],
-          minifyIdentifiers: true,
-          minifySyntax: true,
-          minifyWhitespace: true,
+        rolldownOptions: {
+          output: {
+            minify: {
+              compress: {
+                dropConsole: true,
+                dropDebugger: true,
+              },
+            },
+          },
         },
       }),
     },

--- a/templates/v2/template-reactless/my_component/frontend/package.json
+++ b/templates/v2/template-reactless/my_component/frontend/package.json
@@ -25,8 +25,8 @@
     "cross-env": "^10.1.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.1.0",
-    "typescript": "^5.8.3",
-    "vite": "^7.1.12"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
   }
 }
 

--- a/templates/v2/template-reactless/my_component/frontend/tsconfig.json
+++ b/templates/v2/template-reactless/my_component/frontend/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/templates/v2/template-reactless/my_component/frontend/vite.config.ts
+++ b/templates/v2/template-reactless/my_component/frontend/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(() => {
       "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
     build: {
-      minify: isDev ? false : "esbuild",
+      minify: isDev ? false : "oxc",
       outDir: "build",
       sourcemap: isDev,
       lib: {
@@ -24,11 +24,15 @@ export default defineConfig(() => {
         fileName: "index-[hash]",
       },
       ...(!isDev && {
-        esbuild: {
-          drop: ["console", "debugger"],
-          minifyIdentifiers: true,
-          minifySyntax: true,
-          minifyWhitespace: true,
+        rolldownOptions: {
+          output: {
+            minify: {
+              compress: {
+                dropConsole: true,
+                dropDebugger: true,
+              },
+            },
+          },
         },
       }),
     },

--- a/templates/v2/template/my_component/frontend/package.json
+++ b/templates/v2/template/my_component/frontend/package.json
@@ -27,11 +27,11 @@
     "@types/node": "^22.14.1",
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
-    "@vitejs/plugin-react": "^5.1.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "cross-env": "^10.1.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.1.0",
-    "typescript": "^5.8.3",
-    "vite": "^7.1.12"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
   }
 }

--- a/templates/v2/template/my_component/frontend/tsconfig.json
+++ b/templates/v2/template/my_component/frontend/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/templates/v2/template/my_component/frontend/vite.config.ts
+++ b/templates/v2/template/my_component/frontend/vite.config.ts
@@ -1,6 +1,6 @@
 import react from "@vitejs/plugin-react";
 import process from "node:process";
-import { defineConfig, loadEnv, UserConfig } from "vite";
+import { defineConfig, UserConfig } from "vite";
 
 /**
  * Vite configuration for Streamlit Custom Component v2 development using React.
@@ -20,7 +20,7 @@ export default defineConfig(() => {
       "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
     build: {
-      minify: isDev ? false : "esbuild",
+      minify: isDev ? false : "oxc",
       outDir: "build",
       sourcemap: isDev,
       lib: {
@@ -30,11 +30,15 @@ export default defineConfig(() => {
         fileName: "index-[hash]",
       },
       ...(!isDev && {
-        esbuild: {
-          drop: ["console", "debugger"],
-          minifyIdentifiers: true,
-          minifySyntax: true,
-          minifyWhitespace: true,
+        rolldownOptions: {
+          output: {
+            minify: {
+              compress: {
+                dropConsole: true,
+                dropDebugger: true,
+              },
+            },
+          },
         },
       }),
     },


### PR DESCRIPTION
Fixes #157

## Summary
- Upgrade the v2 cookiecutter frontend templates to TypeScript 6.0.3 and Vite 8.0.10. The React variant also bumps `@vitejs/plugin-react` to 6.0.1.
- Change the v2 frontend `tsconfig.json` files from `moduleResolution: \"node\"` to `moduleResolution: \"bundler\"` so generated projects do not hit the TypeScript 6 `node10` deprecation warning.
- Update the v2 `vite.config.ts` production minification settings for Vite 8 and regenerate the checked-in `templates/v2/*` outputs.
- Keep the change v2-only; `v1` templates and examples are unchanged.