### PR TITLE
ci: add Dependabot config and examples-update-deps helper

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot configuration.
+#
+# Every frontend package.json in this repo is entangled in a cross-manifest
+# equality check, and Dependabot updates one directory per PR and cannot
+# coordinate across manifests. That shapes what we let it watch:
+#
+#   - examples-check-deps requires each example's shared toolchain versions
+#     (vite, react, typescript, ...) to match the v1 template exactly.
+#   - templates-check-not-modified requires each rendered template to match its
+#     cookiecutter source.
+#
+# So we only point npm at the examples. For deps the template does NOT declare
+# (baseui, lodash, styletron, ...), Dependabot PRs are independent and merge
+# cleanly. For the shared toolchain, a lone example bump will fail
+# examples-check-deps by design: treat that PR as a signal, then land the bump
+# holistically by editing the cookiecutter source and running
+#   ./dev.py templates-update && ./dev.py examples-update-deps && ./dev.py all-npm-install
+#
+# Rendered templates and cookiecutter sources are intentionally NOT watched: a
+# lone bump there would break the checks above.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/examples/**/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Collapse the shared build toolchain into one PR per example so a Vite
+      # bump arrives as a single coordinated change instead of one PR each for
+      # vite, @vitejs/plugin-react-swc, esbuild, and friends.
+      frontend-toolchain:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "esbuild"
+          - "rollup"
+          - "rolldown"
+          - "postcss"
+          - "typescript"
+          - "prettier"
+          - "@types/node"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+
+  # GitHub Actions have no cross-manifest constraint, so these PRs are always
+  # mergeable on their own. Keeps actions/checkout, actions/setup-node, etc. current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/dev.py
+++ b/dev.py
@@ -318,6 +318,61 @@ def cmd_example_check_deps(args):
     sys.exit(exit_code)
 
 
+def cmd_example_update_deps(args):
+    """Sync the template's shared dependency versions into every example.
+
+    This is the write counterpart of ``examples-check-deps``: for each version
+    the v1 template declares, it rewrites that version in every example's
+    package.json so the check passes. Only the specific version strings are
+    touched, so the rest of each file (formatting, extra deps) is left intact.
+    Run ``all-npm-install`` afterwards to refresh the lockfiles.
+    """
+    template_package_json = json.loads(
+        (
+            THIS_DIRECTORY
+            / "templates"
+            / "v1"
+            / "template"
+            / "my_component"
+            / "frontend"
+            / "package.json"
+        ).read_text()
+    )
+    examples_package_jsons = sorted(
+        next(d.glob("*/frontend/package.json")) for d in EXAMPLE_DIRECTORIES
+    )
+    changed_any = False
+    for examples_package_json in examples_package_jsons:
+        text = examples_package_json.read_text()
+        example_package_json = json.loads(text)
+        rel = examples_package_json.relative_to(THIS_DIRECTORY)
+        for section_name in ("dependencies", "devDependencies"):
+            template_deps = template_package_json.get(section_name, dict())
+            example_deps = example_package_json.get(section_name, dict())
+            for k, v in template_deps.items():
+                current_version = example_deps.get(k)
+                if current_version is None:
+                    print(
+                        f"WARNING: {rel!s} is missing {k!r} in {section_name!r}. "
+                        f"Add it manually as {v!r}."
+                    )
+                    continue
+                if current_version != v:
+                    text = text.replace(
+                        f'"{k}": "{current_version}"', f'"{k}": "{v}"'
+                    )
+                    print(f"{rel!s}: {k} {current_version} -> {v}")
+                    changed_any = True
+        examples_package_json.write_text(text)
+
+    if changed_any:
+        print()
+        print("Dependency versions synced. Refresh the lockfiles with:")
+        print("  ./dev.py all-npm-install")
+    else:
+        print("All examples already match the template. Nothing to do.")
+
+
 def cmd_check_test_utils(args):
     """Check that e2e utils files are identical"""
     file_list = glob.glob("**/e2e_utils.py", recursive=True)
@@ -497,6 +552,7 @@ COMMANDS = {
     "all-npm-build": {"fn": cmd_all_npm_build},
     "all-python-build-package": {"fn": cmd_all_python_build_package},
     "examples-check-deps": {"fn": cmd_example_check_deps},
+    "examples-update-deps": {"fn": cmd_example_update_deps},
     "templates-check-not-modified": {"fn": cmd_check_templates_using_cookiecutter},
     "templates-update": {"fn": cmd_update_templates},
     "e2e-utils-check": {"fn": cmd_check_test_utils},


### PR DESCRIPTION
**Before:** no `.github/dependabot.yml` (the recent bump PRs were default security updates), and no command to propagate the template's shared dependency versions into the examples, so `examples-check-deps` could only validate, never fix.

**After:** a Dependabot config that watches the examples for npm (shared build toolchain grouped into one PR per example) plus a `github-actions` updater, and a new `./dev.py examples-update-deps` command that syncs the template's shared versions into every example. Landing a shared-toolchain bump is now `templates-update && examples-update-deps && all-npm-install`.

Note: because every manifest is in a cross-manifest equality check, Dependabot can't make shared-toolchain PRs green on arrival; templates and cookiecutter sources are intentionally excluded (explained in the config comments).